### PR TITLE
Fixed deprecation waring by updating version check logic

### DIFF
--- a/includes/functions-general.php
+++ b/includes/functions-general.php
@@ -291,23 +291,17 @@ class Fact_Maven_Disable_Blogging_General {
     }
 
     public function comment_options() {
-                function compatible() {
-                    return (
-                        intval( explode( '.', get_bloginfo('version') )[0]) >= 5
-                        && intval( explode('.', get_bloginfo('version') )[1]) >= 5
-                    ) ? true : false;
-                }
         # 'Allow people to post comments on new articles' (unchecked)
         update_option( 'default_comment_status', 0 );
         # 'Comment must be manually approved' (checked)
         update_option( 'comment_moderation', 1 );
-                # 'Comment author must have a previously approved comment' (checked)
-                if ( compatible() ) {
-                    update_option( 'comment_previously_approved', 1 );
-                }
-                else {
-                    update_option( 'comment_whitelist', 1 ); # deprecated since WP 5.5.0
-                }
+        # 'Comment author must have a previously approved comment' (checked)
+        if ( version_compare( get_bloginfo('version'), '5.5', '>=' ) ) {
+            update_option( 'comment_previously_approved', 1 );
+        }
+        else {
+            update_option( 'comment_whitelist', 1 ); # deprecated since WP 5.5.0
+        }
     }
 
     public function existing_comments( $comments ) {


### PR DESCRIPTION
This is a follow-up to the issue I created on wordpress.org https://wordpress.org/support/topic/deprecated-update_option-value-due-to-error-in-the-code/

And closes also the other one related: https://wordpress.org/support/topic/update_option-with-deprecated-argument/

Closes #23 